### PR TITLE
✨ Refactor fetch_posts function to only fetch post ID and title

### DIFF
--- a/lib/blog.ex
+++ b/lib/blog.ex
@@ -10,7 +10,7 @@ defmodule Blog do
   """
   alias Cognac, as: C
 
-  def fetch_posts(count \\ 10, attr \\ [:id, :title, :body]) do
+  def fetch_posts(count \\ 10, attr \\ [:id, :title]) do
     base_url = "https://api.github.com/graphql"
 
     headers =
@@ -18,7 +18,7 @@ defmodule Blog do
 
     query = [
       repository:
-        {[owner: "tlarevo", name: "cms"],
+        {[owner: "tlarevo", name: "blog"],
          [
            discussions:
              {[first: count, orderBy: [field: :CREATED_AT, direction: :DESC]], [nodes: attr]}


### PR DESCRIPTION
Updated the fetch_posts function in the Blog module to only fetch post ID
and title attributes instead of body. Made changes to improve readability
and efficiency in the code.